### PR TITLE
CC01-13: Integrate AWS SES email + SNS SMS into the communication system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,10 @@ RESEND_API_KEY=re_your-resend-api-key
 RESEND_FROM_EMAIL=noreply@yourdomain.com
 
 # SMTP Configuration for emails
+# For AWS SES (dev/staging only until SES production access is granted):
+#   SMTP_HOST=email-smtp.eu-west-1.amazonaws.com, SMTP_PORT=587,
+#   SMTP_USERNAME/SMTP_PASSWORD = SES SMTP credentials (not IAM access keys),
+#   SMTP_FROM_EMAIL = an SES-verified identity.
 SMTP_HOST=your-smtp-host
 SMTP_PORT=587
 SMTP_USERNAME=your-smtp-username
@@ -48,6 +52,12 @@ SMTP_PASSWORD=your-smtp-password
 SMTP_FROM_EMAIL=your-smtp-from-email # Sender address(e.g. noreply@yourdomain.com)
 # Set to true for port 465
 # SMTP_SECURE=false
+
+# AWS Configuration for SNS SMS sending
+# See docs/reference/AWS_SES_SNS_SETUP.md (sandbox: verified numbers only)
+AWS_REGION=eu-west-1
+AWS_ACCESS_KEY_ID=your-aws-access-key-id
+AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
 
 
 # Sentry Error Tracking Configuration

--- a/docs/reference/AWS_SES_SNS_SETUP.md
+++ b/docs/reference/AWS_SES_SNS_SETUP.md
@@ -1,0 +1,96 @@
+# AWS SES Email + SNS SMS Setup and Sandbox Limitations
+
+**Status:** Verified working in sandbox mode (2026-06-04)
+**AWS account:** 479279106824 · **IAM user:** `VyteTeam` · **Region:** `eu-west-1`
+**Test scripts:** `/apps/campos/aws` (Node project; credentials in local `.env`, not committed)
+
+CampOS can send email via AWS SES and SMS via AWS SNS. Both channels are verified end-to-end but remain in **sandbox mode**, which restricts who we can send to and how much. This document records the current setup, the sandbox limits the team must design around, and the steps required to go to production.
+
+> Note: booking confirmation emails currently use **Resend** (see `docs/RESEND_SETUP.md`). AWS SES/SNS is a separate, verified channel — primarily relevant for SMS and any future AWS-native messaging.
+
+## Email — AWS SES ✅ working (sandbox)
+
+| Item | State |
+|---|---|
+| Sending enabled | Yes |
+| Mode | **Sandbox** — production access NOT granted |
+| Quota | 200 emails / 24 h, max 1 message/second |
+| Verified identities | `me@jnbruno.com` (single email identity) |
+| Verified test send | 2026-06-04, MessageId `0102019e9088e8b0-730c8f9e-f6e8-4990-b2f8-1669baf322a1-000000` |
+
+### Sandbox restrictions (email)
+
+- **Recipients must also be verified identities.** You cannot email arbitrary addresses until production access is granted.
+- 200 emails per 24 hours, 1 msg/s send rate.
+
+### Gotcha: identity verification links expire
+
+SES identity verification links expire after **24 hours**. If the link wasn't clicked in time, the identity stays stuck in "pending" — delete the identity and recreate it to trigger a fresh verification email. `verify-identity.js` handles status checks.
+
+## SMS — AWS SNS ✅ working (sandbox)
+
+| Item | State |
+|---|---|
+| Service subscription | Activated 2026-06-04 (previously failed with `SubscriptionRequiredException`; resolved by the account owner in the console — payment/activation issue) |
+| Mode | **SMS sandbox** |
+| Spend cap | USD 1.00 / month |
+| Verified destinations | +639174740855 (PH) |
+| Verified test send | 2026-06-04, MessageId `fe8fe645-a024-5133-9876-84ded51dd8c6` |
+
+### Sandbox restrictions (SMS)
+
+- **Destination numbers must be verified first** (OTP flow — see `verify-sms-number.js`).
+- Monthly spend is capped at USD 1.00 until an increase is approved.
+
+### IAM note
+
+`VyteTeam` has SNS permissions but **no `sms-voice:*`** — the newer AWS End User Messaging API is denied (`AccessDenied`). SMS sends therefore go through the classic SNS publish path. `check-sms.js` is kept ready for when IAM is widened.
+
+## Test scripts (`/apps/campos/aws`)
+
+| Script | Purpose |
+|---|---|
+| `test-aws.js` | STS credential check |
+| `check-ses-sns.js` | SES account/identities + SNS SMS status |
+| `check-sms.js` | End User Messaging (sms-voice) status — currently AccessDenied, kept for when IAM is widened |
+| `verify-identity.js <email>` | SES identity create/check |
+| `send-test-email.js <from> [to]` | SES send test |
+| `verify-sms-number.js <phone> [otp]` | SMS sandbox destination verification (OTP flow) |
+| `send-test-sms.js <phone> [message]` | SNS SMS send test (Transactional type) |
+
+Credentials are read from a local `.env` in that directory — never commit it.
+
+## App integration (CC01-13)
+
+CampOS is wired to both channels through the existing communication system:
+
+### Email — via the SES SMTP interface (config-only)
+
+The app sends all email through SMTP (`src/lib/email/emailit.ts`), so SES needs no code change. Set the `SMTP_*` env vars to SES SMTP values (see `.env.example`): host `email-smtp.eu-west-1.amazonaws.com`, port 587, username/password = **SES SMTP credentials** (generated in the SES console — distinct from IAM access keys), from = a verified identity.
+
+**Rollout decision (2026-06-04):** dev/staging point at SES SMTP now; **production keeps its current SMTP provider** until SES production access is granted — otherwise live guest emails to unverified addresses would fail.
+
+### SMS — via AWS SNS
+
+- **Provider:** `src/lib/messaging/providers/sms.ts` — `sendSMS(to, body)` publishes through SNS (`Transactional` type, E.164 normalisation, 4-attempt retry). It never throws; all failures return `{ success: false, error }`. Env: `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` (server-side only).
+- **Reach:** this one provider powers the Guest Communication SMS inbox direct sends (`POST /api/v1/guests/[id]/messages`), SMS/both campaigns (`src/lib/messaging/send.ts`), and the automation action below. Deliveries are logged to `communication_log`.
+- **Automation action:** `send_sms` (`src/lib/automations/action-registry.ts`) — config takes `template` (an `sms_templates` slug, what the automations UI writes) or an inline `message` string; merge fields like `{{guest.first_name}}` are rendered. Recipient is the **guest only** (staff SMS needs staff-phone context — not available yet). The action checks `communication_opt_outs` (channel `sms`) and writes `communication_log` rows (`sent` → `delivered`/`failed`, or `skipped` on opt-out).
+
+### Known follow-ups
+
+- SMS inbox thread history calls `GET /api/v1/guests/[id]/messages`, but the route only implements POST — history display needs a GET handler (separate task).
+- Inbound STOP: SNS honours carrier STOP automatically; mirroring it into `communication_opt_outs` (`source: 'sms_stop'`) needs an inbound webhook (separate task).
+
+## Going to production (not yet done)
+
+1. **SES production access** — submit the one-off production access request in the SES console. At the same time, verify a sending **domain** with DKIM instead of individual email addresses.
+2. **SNS SMS sandbox exit** — open a support case to exit the SMS sandbox and request a spend-limit increase. Choose an origination identity per destination country:
+   - **PH:** registered alphanumeric sender ID recommended for deliverability.
+   - **US:** would require a 10DLC or toll-free number.
+3. **Optional IAM widening** — grant `sms-voice:*` to `VyteTeam` to enable the newer End User Messaging API (then `check-sms.js` becomes usable).
+
+## What this means for feature work
+
+- Any feature sending email via SES today can only reach **verified addresses** and ≤200/day.
+- Any feature sending SMS can only reach **verified phone numbers** and ≤USD 1.00/month of traffic.
+- Do not build user-facing flows that assume unrestricted sending until the production steps above are completed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "my-v0-project",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-sns": "^3.1061.0",
         "@emotion/is-prop-valid": "1.2.2",
         "@hookform/resolvers": "3.9.1",
         "@radix-ui/react-accordion": "1.2.2",
@@ -189,6 +190,358 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns": {
+      "version": "3.1061.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1061.0.tgz",
+      "integrity": "sha512-i15s29IGv0sgqwNW2QiwJE6QOOpRJxYm6eszWgQ+cfIXbPWPFSdngc1u56GczCPy1y9fAqEqXU4Ou1uLuE1btQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/credential-provider-node": "^3.972.50",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.17.tgz",
+      "integrity": "sha512-r8o4h2K7j6P9ngno+8ei0aK0U/4JwDb7A2fMMxGVoSqDN8AFlIzSDeZHME9LcVLR2codyhtr1WAAg+/nmkeeMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.10",
+        "@aws-sdk/xml-builder": "^3.972.27",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.43.tgz",
+      "integrity": "sha512-g0XVQKzaA/4cq1vz1IvCQwYM+1Pkv01J9yHDpCTXekVuGZRDEz0wqBQ1AuYTq7FM6uik4uBGH8Tb5d9YvgeA7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.45.tgz",
+      "integrity": "sha512-w9PuOoKCt6+xoESvY+zlV0u3PKQ0mVL259PcsVR6a3S/uYJJHnIi4r1NxdJHEcNldUVRIciltWnFMGBR4YEm3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.48.tgz",
+      "integrity": "sha512-+6BQ6Lrnc+EyAGElLRW6j+Sa+RirPHnIJsobvYO6nnyK+oGKmz1ne/ieclbLWyjyDKEU3/JVJWcWY3VLFPvGtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/credential-provider-env": "^3.972.43",
+        "@aws-sdk/credential-provider-http": "^3.972.45",
+        "@aws-sdk/credential-provider-login": "^3.972.47",
+        "@aws-sdk/credential-provider-process": "^3.972.43",
+        "@aws-sdk/credential-provider-sso": "^3.972.47",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.47",
+        "@aws-sdk/nested-clients": "^3.997.15",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.47.tgz",
+      "integrity": "sha512-Iy2ebWVgrZBH05464uJiQYu6HSSiROnwVZptthEFXx2gWjo1ORCxEAFZB5Cr2MdfrSnZ+0QUPkZ1ZpCqpkUrLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/nested-clients": "^3.997.15",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.50.tgz",
+      "integrity": "sha512-b05Aelq5cqAvCCDQjCYacl0XmR8QhBNSqLbsdISkQmlQBa5oPS66zYPteWcSp5LswbpoIe552EUGjluKiadBig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.43",
+        "@aws-sdk/credential-provider-http": "^3.972.45",
+        "@aws-sdk/credential-provider-ini": "^3.972.48",
+        "@aws-sdk/credential-provider-process": "^3.972.43",
+        "@aws-sdk/credential-provider-sso": "^3.972.47",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.47",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.43.tgz",
+      "integrity": "sha512-GPokLNyvTfCmuaHk+v3GKVs4ZT3cMu5kgS2a+NPkOMt96cq6fSIK0g+mZHpGS6Cd4QGrPKesANEaLUKgOskTzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.47.tgz",
+      "integrity": "sha512-0AzvLrzlvJs0DzbeWGvNj+bX3Uzd7VNS6vDqCOdZzBlCGKGd78uxctJSW9iK/Rt/nxiJqpTvrYQlVJ4guVM2Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/nested-clients": "^3.997.15",
+        "@aws-sdk/token-providers": "3.1060.0",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.47.tgz",
+      "integrity": "sha512-eksfbUErOejUAGWBAcNqaP7IX21oUOEo73d9R56k9Ua4d57qS90NEYkWJsuSGzTXMFulCu17qXJI/qGmM7hvoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/nested-clients": "^3.997.15",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.15.tgz",
+      "integrity": "sha512-Fpri1/PXKMKveORZ7E00VLTlWS5DkfZkW70PUE+bOnpWpAeHAQLoiDHhkzN3kNWbbSsGg64+IZYiq/EZgME3Mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.31",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.31.tgz",
+      "integrity": "sha512-Kn2up9SlG1KC6wRtwf0d7waTGF6rvp9DxYqB54x6UCKdQ6kyaXCqHL4WGb5vUJga5kS8FxnjhY0LqM28aMvnNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1060.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1060.0.tgz",
+      "integrity": "sha512-6NZaMKkFhpaNiwLpHi1sZaYjidL/lCJE6ME6NxwA8gv9vQna+Kr0j4OFwVoz6tANRWM3WbGz6jiPsGX/Vkjwow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/nested-clients": "^3.997.15",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.10.tgz",
+      "integrity": "sha512-992QrTO7G9qCvKD0fx1rMlqcL14plUcRAbwmqqYVsuF3GrqcvlAL9qxR+baMafarEZ+l7DUQ5lCMmt5mbMhF7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.27.tgz",
+      "integrity": "sha512-hpsCXCOI436kxWpjtRuIHVvuPP81MOw8f18jzfZeg+UOiiOvlqWcmWChzEhJEu16cOC6+ku4ncBN+7rdt+DZ9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -2277,6 +2630,18 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5635,6 +6000,126 @@
         "webpack": ">=5.0.0"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.7.tgz",
+      "integrity": "sha512-xj8gq/bjFABAh6qWPSDCYcY3kzQIm4b561C+YnHH4zGq8rOgzQ3Shk+JGlpUxSd41UGiO6FkLdUCtNX1FAeHgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.6.tgz",
+      "integrity": "sha512-3fya8i7GrJilQouk4cZJKdy5k8MWQBpjfXrRNaXDedH8r779tr0jcxyH3+yoTmsluc2+vF4S343yFbnvu8ExDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -7480,6 +7965,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -9512,6 +10003,43 @@
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -12111,6 +12639,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -14250,6 +14793,18 @@
         }
       }
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -15470,6 +16025,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "cron": "tsx cron.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-sns": "^3.1061.0",
     "@emotion/is-prop-valid": "1.2.2",
     "@hookform/resolvers": "3.9.1",
     "@radix-ui/react-accordion": "1.2.2",

--- a/src/lib/automations/action-registry.ts
+++ b/src/lib/automations/action-registry.ts
@@ -68,7 +68,6 @@ export function createActionRegistry(): ActionHandlerMap {
     'create_work_order',
     'assign_staff',
     'update_site_status',
-    'send_sms',
     'log_activity',
     'create_audit_entry',
   ]
@@ -381,6 +380,178 @@ export function createActionRegistry(): ActionHandlerMap {
         }
       } catch (err) {
         console.error(`[send_email] Error sending template "${templateSlug}":`, err)
+      }
+    },
+  })
+
+  // send_sms: sends an SMS to the guest via AWS SNS.
+  // Message body comes from an sms_templates slug (config.template — what the
+  // automations UI writes) or an inline config.message string.
+  registry.set('send_sms', {
+    async execute(config, context) {
+      const templateSlug = config.template as string | undefined
+      const inlineMessage = config.message as string | undefined
+      if (!templateSlug && !inlineMessage) {
+        console.error('[send_sms] No template slug or message in action_config')
+        return
+      }
+
+      try {
+        const { createServiceRoleClient } = await import('@/lib/supabase/service-role')
+        const { sendSMS } = await import('@/lib/messaging/providers/sms')
+        const { enrichContext, replaceVariables } = await import(
+          '@/lib/email/template-renderer'
+        )
+
+        const supabase = createServiceRoleClient()
+
+        const companyId = context.property?.company_id as string | undefined
+        if (!companyId) {
+          console.error('[send_sms] Cannot determine company_id from context')
+          return
+        }
+
+        const propertyId = context.property?.id as string | undefined
+        const guestId = context.guest?.id as string | undefined
+
+        // Recipient: guest only. Staff/vendor context has no phone today.
+        const recipientPhone = context.guest?.phone as string | undefined
+        if (!recipientPhone) {
+          console.error('[send_sms] No guest phone number in context')
+          return
+        }
+
+        // Resolve message body: template slug (property-specific → tenant-level)
+        // or inline message
+        let templateId: string | null = null
+        let messageTemplate = inlineMessage ?? ''
+
+        if (templateSlug) {
+          let template: { id: string; body: string } | null = null
+
+          if (propertyId) {
+            const { data } = await supabase
+              .from('sms_templates')
+              .select('id, body')
+              .eq('company_id', companyId)
+              .eq('property_id', propertyId)
+              .eq('slug', templateSlug)
+              .eq('status', 'active')
+              .limit(1)
+              .single()
+            if (data) template = data
+          }
+
+          if (!template) {
+            const { data } = await supabase
+              .from('sms_templates')
+              .select('id, body')
+              .eq('company_id', companyId)
+              .is('property_id', null)
+              .eq('slug', templateSlug)
+              .eq('status', 'active')
+              .limit(1)
+              .single()
+            if (data) template = data
+          }
+
+          if (!template) {
+            console.error(`[send_sms] Template "${templateSlug}" not found for tenant ${companyId}`)
+            return
+          }
+
+          templateId = template.id
+          messageTemplate = template.body
+        }
+
+        // ── Opt-out check (non-blocking) ────────────────────────────────────
+        if (guestId && propertyId) {
+          try {
+            const { isOptedOut } = await import('@/lib/communications/opt-out-checker')
+            const { logDelivery } = await import('@/lib/communications/delivery-logger')
+
+            const optedOut = await isOptedOut(supabase, companyId, guestId, 'sms')
+            if (optedOut) {
+              await logDelivery({
+                supabase,
+                companyId,
+                propertyId,
+                guestId,
+                templateId,
+                channel: 'sms',
+                recipientAddress: recipientPhone,
+                subject: null,
+                status: 'skipped',
+              }).catch(() => {})
+              console.log(`[send_sms] Skipped — guest ${guestId} opted out of SMS`)
+              return
+            }
+          } catch (optOutErr) {
+            console.error('[send_sms] Opt-out check failed, proceeding with send:', optOutErr)
+          }
+        }
+
+        // ── Render message with merge fields ─────────────────────────────────
+        const ctxRecord = context as unknown as Record<string, unknown>
+        const enriched = enrichContext(ctxRecord)
+        const message = replaceVariables(messageTemplate, enriched)
+
+        // ── Log delivery (non-blocking) ──────────────────────────────────────
+        let deliveryLog: { id: string } | null = null
+        try {
+          const { logDelivery } = await import('@/lib/communications/delivery-logger')
+          deliveryLog = await logDelivery({
+            supabase,
+            companyId,
+            propertyId: propertyId ?? '',
+            reservationId: context.reservation?.id as string | null,
+            guestId: guestId ?? null,
+            templateId,
+            channel: 'sms',
+            recipientAddress: recipientPhone,
+            subject: null,
+            status: 'sent',
+          })
+        } catch (logErr) {
+          console.error('[send_sms] Delivery log failed, sending anyway:', logErr)
+        }
+
+        // ── Send SMS ─────────────────────────────────────────────────────────
+        const result = await sendSMS(recipientPhone, message)
+
+        // ── Update delivery status (non-blocking) ────────────────────────────
+        if (deliveryLog) {
+          try {
+            const { updateDeliveryStatus } = await import('@/lib/communications/delivery-logger')
+            if (result.success) {
+              await updateDeliveryStatus({
+                supabase,
+                logId: deliveryLog.id,
+                status: 'delivered',
+                deliveredAt: new Date().toISOString(),
+              })
+            } else {
+              await updateDeliveryStatus({
+                supabase,
+                logId: deliveryLog.id,
+                status: 'failed',
+                failureReason: result.error ?? null,
+              })
+            }
+          } catch (statusErr) {
+            console.error('[send_sms] Delivery status update failed:', statusErr)
+          }
+        }
+
+        if (!result.success) {
+          console.error('[send_sms] Failed to send SMS:', result.error)
+        } else {
+          console.log(
+            `[send_sms] Sent SMS to ${recipientPhone} (id: ${result.providerMessageId})`,
+          )
+        }
+      } catch (err) {
+        console.error('[send_sms] Error sending SMS:', err)
       }
     },
   })

--- a/src/lib/automations/send-sms-action.test.ts
+++ b/src/lib/automations/send-sms-action.test.ts
@@ -1,0 +1,163 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import type { EventContext } from './types'
+
+const { sendSMSMock, logDeliveryMock, updateDeliveryStatusMock, isOptedOutMock, fromMock } =
+  vi.hoisted(() => ({
+    sendSMSMock: vi.fn(),
+    logDeliveryMock: vi.fn(),
+    updateDeliveryStatusMock: vi.fn(),
+    isOptedOutMock: vi.fn(),
+    fromMock: vi.fn(),
+  }))
+
+vi.mock('@/lib/supabase/service-role', () => ({
+  createServiceRoleClient: () => ({ from: fromMock }),
+}))
+
+vi.mock('@/lib/messaging/providers/sms', () => ({
+  sendSMS: sendSMSMock,
+}))
+
+vi.mock('@/lib/communications/delivery-logger', () => ({
+  logDelivery: logDeliveryMock,
+  updateDeliveryStatus: updateDeliveryStatusMock,
+}))
+
+vi.mock('@/lib/communications/opt-out-checker', () => ({
+  isOptedOut: isOptedOutMock,
+}))
+
+import { createActionRegistry } from './action-registry'
+
+function makeQuery(result: { data: unknown; error: unknown }) {
+  const query: Record<string, unknown> = {}
+  query.select = () => query
+  query.eq = () => query
+  query.is = () => query
+  query.limit = () => query
+  query.single = () => Promise.resolve(result)
+  return query
+}
+
+function makeContext(overrides: Partial<Record<string, unknown>> = {}): EventContext {
+  return {
+    property: { id: 'prop-1', company_id: 'co-1' },
+    guest: {
+      id: 'guest-1',
+      first_name: 'Maria',
+      last_name: 'Santos',
+      phone: '+639174740855',
+    },
+    reservation: { id: 'res-1' },
+    ...overrides,
+  } as unknown as EventContext
+}
+
+function getHandler() {
+  const registry = createActionRegistry()
+  const handler = registry.get('send_sms')
+  if (!handler) throw new Error('send_sms handler not registered')
+  return handler
+}
+
+beforeEach(() => {
+  sendSMSMock.mockReset().mockResolvedValue({ success: true, providerMessageId: 'sns-id-1' })
+  logDeliveryMock.mockReset().mockResolvedValue({ id: 'log-1' })
+  updateDeliveryStatusMock.mockReset().mockResolvedValue({ id: 'log-1' })
+  isOptedOutMock.mockReset().mockResolvedValue(false)
+  fromMock.mockReset().mockReturnValue(makeQuery({ data: null, error: null }))
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('send_sms action', () => {
+  test('inline message: renders merge fields, sends, logs sent then delivered', async () => {
+    await getHandler().execute(
+      { message: 'Hi {{guest.first_name}}, your booking is confirmed' },
+      makeContext(),
+    )
+
+    expect(sendSMSMock).toHaveBeenCalledWith(
+      '+639174740855',
+      'Hi Maria, your booking is confirmed',
+    )
+    expect(logDeliveryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        companyId: 'co-1',
+        propertyId: 'prop-1',
+        guestId: 'guest-1',
+        channel: 'sms',
+        recipientAddress: '+639174740855',
+        subject: null,
+        status: 'sent',
+      }),
+    )
+    expect(updateDeliveryStatusMock).toHaveBeenCalledWith(
+      expect.objectContaining({ logId: 'log-1', status: 'delivered' }),
+    )
+  })
+
+  test('template slug: resolves sms_templates body and renders it', async () => {
+    fromMock.mockReturnValueOnce(
+      makeQuery({
+        data: { id: 'tpl-1', body: 'Hello {{guest.first_name}}, see you soon!' },
+        error: null,
+      }),
+    )
+
+    await getHandler().execute({ template: 'pre_arrival_sms' }, makeContext())
+
+    expect(fromMock).toHaveBeenCalledWith('sms_templates')
+    expect(sendSMSMock).toHaveBeenCalledWith('+639174740855', 'Hello Maria, see you soon!')
+    expect(logDeliveryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ templateId: 'tpl-1', channel: 'sms', status: 'sent' }),
+    )
+  })
+
+  test('template not found: no send, error logged', async () => {
+    await getHandler().execute({ template: 'missing_template' }, makeContext())
+
+    expect(sendSMSMock).not.toHaveBeenCalled()
+    expect(logDeliveryMock).not.toHaveBeenCalled()
+  })
+
+  test('opted-out guest: logs skipped, never sends', async () => {
+    isOptedOutMock.mockResolvedValue(true)
+
+    await getHandler().execute({ message: 'Hello' }, makeContext())
+
+    expect(isOptedOutMock).toHaveBeenCalledWith(expect.anything(), 'co-1', 'guest-1', 'sms')
+    expect(sendSMSMock).not.toHaveBeenCalled()
+    expect(logDeliveryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'sms', status: 'skipped' }),
+    )
+  })
+
+  test('missing message and template: no send, no throw', async () => {
+    await expect(getHandler().execute({}, makeContext())).resolves.toBeUndefined()
+    expect(sendSMSMock).not.toHaveBeenCalled()
+  })
+
+  test('missing guest phone: no send, no throw', async () => {
+    const context = makeContext({
+      guest: { id: 'guest-1', first_name: 'Maria', last_name: 'Santos', phone: null },
+    })
+
+    await expect(getHandler().execute({ message: 'Hello' }, context)).resolves.toBeUndefined()
+    expect(sendSMSMock).not.toHaveBeenCalled()
+  })
+
+  test('send failure: delivery status updated to failed with reason', async () => {
+    sendSMSMock.mockResolvedValue({ success: false, error: 'ThrottledException' })
+
+    await getHandler().execute({ message: 'Hello' }, makeContext())
+
+    expect(updateDeliveryStatusMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        logId: 'log-1',
+        status: 'failed',
+        failureReason: 'ThrottledException',
+      }),
+    )
+  })
+})

--- a/src/lib/messaging/providers/sms.test.ts
+++ b/src/lib/messaging/providers/sms.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { sendMock } = vi.hoisted(() => ({ sendMock: vi.fn() }))
+
+vi.mock('@aws-sdk/client-sns', () => ({
+  SNSClient: class {
+    send = sendMock
+  },
+  PublishCommand: class {
+    input: unknown
+    constructor(input: unknown) {
+      this.input = input
+    }
+  },
+}))
+
+import { sendSMS, normalisePhone } from './sms'
+
+const ENV_KEYS = ['AWS_REGION', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'] as const
+const savedEnv: Record<string, string | undefined> = {}
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key]
+  }
+  process.env.AWS_REGION = 'eu-west-1'
+  process.env.AWS_ACCESS_KEY_ID = 'test-access-key'
+  process.env.AWS_SECRET_ACCESS_KEY = 'test-secret-key'
+  sendMock.mockReset()
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = savedEnv[key]
+    }
+  }
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('normalisePhone', () => {
+  test('strips spaces, dashes, dots and parentheses', () => {
+    expect(normalisePhone('+63 917 474 0855')).toBe('+639174740855')
+    expect(normalisePhone('+44 (0)20-7946.0958'.replace('(0)', ''))).toBe('+442079460958')
+  })
+
+  test('rejects numbers without + prefix or with wrong length', () => {
+    expect(normalisePhone('639174740855')).toBeNull()
+    expect(normalisePhone('+123')).toBeNull()
+    expect(normalisePhone('+1234567890123456')).toBeNull()
+  })
+
+  test('rejects non-string input', () => {
+    expect(normalisePhone(null)).toBeNull()
+    expect(normalisePhone(undefined)).toBeNull()
+    expect(normalisePhone(639174740855)).toBeNull()
+  })
+})
+
+describe('sendSMS', () => {
+  test('success maps SNS MessageId to providerMessageId and sends Transactional', async () => {
+    sendMock.mockResolvedValueOnce({ MessageId: 'sns-message-id-1' })
+
+    const result = await sendSMS('+63 917 474 0855', 'Hello from CampOS')
+
+    expect(result).toEqual({ success: true, providerMessageId: 'sns-message-id-1' })
+    expect(sendMock).toHaveBeenCalledTimes(1)
+    const command = sendMock.mock.calls[0]?.[0] as { input: Record<string, unknown> } | undefined
+    expect(command?.input).toMatchObject({
+      PhoneNumber: '+639174740855',
+      Message: 'Hello from CampOS',
+      MessageAttributes: {
+        'AWS.SNS.SMS.SMSType': {
+          DataType: 'String',
+          StringValue: 'Transactional',
+        },
+      },
+    })
+  })
+
+  test('returns error result after exactly 4 attempts when SNS keeps failing', async () => {
+    vi.useFakeTimers()
+    sendMock.mockRejectedValue(new Error('ThrottledException'))
+
+    const promise = sendSMS('+639174740855', 'Hello')
+    await vi.runAllTimersAsync()
+    const result = await promise
+
+    expect(result).toEqual({ success: false, error: 'ThrottledException' })
+    expect(sendMock).toHaveBeenCalledTimes(4)
+  })
+
+  test('retries transient failure then succeeds', async () => {
+    vi.useFakeTimers()
+    sendMock
+      .mockRejectedValueOnce(new Error('ServiceUnavailable'))
+      .mockResolvedValueOnce({ MessageId: 'sns-message-id-2' })
+
+    const promise = sendSMS('+639174740855', 'Hello')
+    await vi.runAllTimersAsync()
+    const result = await promise
+
+    expect(result).toEqual({ success: true, providerMessageId: 'sns-message-id-2' })
+    expect(sendMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('invalid phone returns error result without calling SNS', async () => {
+    const result = await sendSMS('not-a-phone', 'Hello')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Invalid phone number')
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  test('missing env config returns error result without throwing', async () => {
+    delete process.env.AWS_REGION
+
+    const result = await sendSMS('+639174740855', 'Hello')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('SNS not configured')
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/messaging/providers/sms.ts
+++ b/src/lib/messaging/providers/sms.ts
@@ -1,33 +1,131 @@
 /**
  * SMS Provider
  *
- * Phase 1 MVP placeholder for SMS sending.
- * Logs SMS details to console and returns a placeholder result.
+ * Sends SMS via AWS SNS (Publish, Transactional type).
  *
- * TODO: Integrate with Twilio, Vonage, or similar SMS provider.
- *       Replace console.log with actual API call.
- *       Add retry logic similar to emailit.
+ * Contract: sendSMS NEVER throws — all failures (missing env, invalid phone,
+ * SNS errors) return { success: false, error }. The campaign send loop in
+ * ../send.ts has no try/catch around this call; a throw would abort the
+ * remaining recipients and strand the campaign in 'sending'.
  */
 
+import { SNSClient, PublishCommand } from '@aws-sdk/client-sns'
 import type { SendResult } from '../messaging-types'
 
-// ============================================================================
-// SMS Sending (MVP Placeholder)
-// ============================================================================
+const SNS_SEND_MAX_ATTEMPTS = 4
+const SNS_RETRY_BASE_DELAY_MS = 500
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+interface SnsConfig {
+  region: string
+  accessKeyId: string
+  secretAccessKey: string
+}
 
 /**
- * Send an SMS message to a single recipient.
- * Phase 1: Logs to console and returns a placeholder success result.
+ * Read SNS config from env. Returns null when incomplete — callers map this
+ * to an error result rather than throwing (see contract above).
+ * Read lazily on every send so env changes (and tests) take effect.
+ */
+function getSnsConfig(): SnsConfig | null {
+  const region = process.env.AWS_REGION
+  const accessKeyId = process.env.AWS_ACCESS_KEY_ID
+  const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY
+  if (!region || !accessKeyId || !secretAccessKey) {
+    return null
+  }
+  return { region, accessKeyId, secretAccessKey }
+}
+
+let client: SNSClient | null = null
+let clientRegion: string | null = null
+
+function getClient(config: SnsConfig): SNSClient {
+  if (!client || clientRegion !== config.region) {
+    client = new SNSClient({
+      region: config.region,
+      credentials: {
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey,
+      },
+    })
+    clientRegion = config.region
+  }
+  return client
+}
+
+/**
+ * Best-effort E.164 normalisation: strips spaces/dashes/dots/parentheses.
+ * Returns null when the result is not a plausible E.164 number
+ * (+ followed by 8–15 digits).
+ */
+export function normalisePhone(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const cleaned = raw.replace(/[\s\-().]/g, '')
+  if (!/^\+\d{8,15}$/.test(cleaned)) return null
+  return cleaned
+}
+
+/**
+ * Send an SMS message to a single recipient via AWS SNS.
+ * Returns the SNS MessageId as providerMessageId on success.
  */
 export async function sendSMS(
   to: string,
   body: string,
 ): Promise<SendResult> {
-  // TODO: Replace with real SMS provider integration (Twilio/Vonage)
-  console.log(`[messaging/sms] Sending SMS to ${to}:`, body.substring(0, 100))
-
-  return {
-    success: true,
-    providerMessageId: `sms-placeholder-${Date.now()}`,
+  const config = getSnsConfig()
+  if (!config) {
+    const error =
+      'SNS not configured: AWS_REGION, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY must be set'
+    console.error(`[messaging/sms] ${error}`)
+    return { success: false, error }
   }
+
+  const phone = normalisePhone(to)
+  if (!phone) {
+    const error = `Invalid phone number (expected E.164): ${String(to)}`
+    console.error(`[messaging/sms] ${error}`)
+    return { success: false, error }
+  }
+
+  const command = new PublishCommand({
+    PhoneNumber: phone,
+    Message: body,
+    MessageAttributes: {
+      'AWS.SNS.SMS.SMSType': {
+        DataType: 'String',
+        StringValue: 'Transactional',
+      },
+    },
+  })
+
+  let lastError = 'Unknown SNS error'
+  for (let attempt = 1; attempt <= SNS_SEND_MAX_ATTEMPTS; attempt++) {
+    try {
+      const result = await getClient(config).send(command)
+      console.log(
+        `[messaging/sms] Sent SMS to ${phone} (id: ${result.MessageId}, attempt: ${attempt}, length: ${body.length})`,
+      )
+      return {
+        success: true,
+        ...(result.MessageId ? { providerMessageId: result.MessageId } : {}),
+      }
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err)
+      console.error(
+        `[messaging/sms] Send to ${phone} failed (attempt ${attempt}/${SNS_SEND_MAX_ATTEMPTS}): ${lastError}`,
+      )
+      if (attempt < SNS_SEND_MAX_ATTEMPTS) {
+        await delay(SNS_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1))
+      }
+    }
+  }
+
+  return { success: false, error: lastError }
 }


### PR DESCRIPTION
## Summary
- Implement the SMS provider seam `src/lib/messaging/providers/sms.ts` with AWS SNS (Transactional type, E.164 normalisation, 4-attempt retry, never-throws contract) — this lights up the existing SMS inbox direct sends and SMS/both campaigns, which previously logged to console and returned fake success
- Replace the `send_sms` automation action stub with a real handler: resolves an `sms_templates` slug (`config.template`, what the automations UI writes) or inline `config.message`, renders merge fields, checks SMS opt-outs, writes `communication_log` rows (sent → delivered/failed, skipped on opt-out)
- Email via SES needs no code: documented SES SMTP env values in `.env.example` (dev/staging only — production stays on the current SMTP provider until SES production access is granted, per recorded decision)
- New reference doc `docs/reference/AWS_SES_SNS_SETUP.md` covering AWS setup, sandbox limits, app integration, and production steps

## Verification
- 15 new unit tests (provider + action handler), all targeted suites green: 66/66 in `src/lib/{messaging,communications,automations}`
- `tsc --noEmit` clean; eslint adds zero new issues (3 pre-existing errors in `action-registry.ts` baseline)
- **Real sandbox SMS delivered through the new provider**: SNS MessageId `285947a9-aa38-5036-ac9b-25322f4fa021` to the verified +63 number (2026-06-04)
- Full unit suite: 66 pre-existing failures on clean `develop` baseline are unchanged (verified by stash-run); no new failures

## Out of scope / follow-ups
- SMS inbox thread history (`GET /api/v1/guests/[id]/messages` has no GET handler — pre-existing)
- Inbound STOP webhook → `communication_opt_outs`
- Staff-recipient SMS (automation context has no staff phone)

Task: https://innotech.ai/campos/campos/task/c6095651-d31b-404e-8e3e-f72aa24042c3